### PR TITLE
Ignore scientific notation and display complete numbers.

### DIFF
--- a/R/check_args.R
+++ b/R/check_args.R
@@ -56,7 +56,8 @@ check_args <- function(cl) { # nolint
         if (length(cl$loc) != 4) {
           error$flag <- 1
           error$message[[length(error$message) + 1]] <- paste0("loc
-           must be a geojson string or a 4 coordinate array")
+           must be an sf object, a geojson string or a 4 coordinate 
+           array c(xmin, xmax, ymax, ymin)")
         }
       }
       }

--- a/R/get_datasets.R
+++ b/R/get_datasets.R
@@ -189,12 +189,9 @@ parse_dataset <- function(result) { # nolint
 #' }
 #' @export
 get_datasets.default <- function(x, ...) { # nolint
-  
+  oo <- options(scipen = 9999999)
+  on.exit(options(oo))
   cl <- as.list(match.call())
-  
-  possible_arguments <- c("contactid", "datasettype", "altmin", "altmax", "loc",
-                          "ageyoung", "ageold", "ageof", "limit", "offset",
-                          "all_data", "sites_o")
   
   cl[[1]] <- NULL
   
@@ -222,7 +219,7 @@ get_datasets.default <- function(x, ...) { # nolint
         }
       }
     }
-    
+
     # loc and all_data present
     if ("all_data" %in% names(cl)){
       result <- parseURL(base_url, all_data = cl$all_data) %>%
@@ -239,11 +236,11 @@ get_datasets.default <- function(x, ...) { # nolint
   
   if (is.null(result$data[1][[1]]) || is.null(result[1][[1]])) {
     return(NULL)
+    
   } else {
     output <- parse_dataset(result)
     return(output)
   }
-  
 }
 
 #' @title Get Dataset Numeric
@@ -311,7 +308,7 @@ get_datasets.sites <- function(x, ...) {
   ## Fixing all data
   cl <- as.list(match.call())
   cl[[1]] <- NULL
- 
+  
   if('all_data' %in% names(cl)){
     all_data = cl$all_data
   }else{

--- a/R/get_sites.R
+++ b/R/get_sites.R
@@ -142,7 +142,9 @@ get_sites <- function(x = NA, ...) {
 #' @param ... One of a set of possible query parameters discussed in details.
 #' @export
 get_sites.default <- function(...) { # nolint
-
+  oo <- options(scipen = 9999999)
+  on.exit(options(oo))
+  
   cl <- as.list(match.call())
 
   cl[[1]] <- NULL

--- a/R/parseURL.R
+++ b/R/parseURL.R
@@ -43,7 +43,6 @@ parseURL <- function(x, use = "neotoma", all_data = FALSE, ...) { # nolint
     response <- httr::GET(paste0(baseurl, x),
                           add_headers("User-Agent" = "neotoma2 R package"),
                           query = query)
-    
     if (response$status_code == 414) {
       # The 414 error is a URL that is too long. This is a lazy way to manage
       # the choice between a POST and GET call.
@@ -148,7 +147,6 @@ parseURL <- function(x, use = "neotoma", all_data = FALSE, ...) { # nolint
         response <- httr::GET(paste0(baseurl, x),
                               add_headers("User-Agent" = "neotoma2 R package"),
                               query = query)
-        
         stop_for_status(response,
                         task = "Could not connect to the Neotoma API.
                     Check that the path is valid, and check the current


### PR DESCRIPTION
Scientific notation error fixed. 
Stop message updated when numeric loc is not of length 4 - accept sf objects