### PR TITLE
Format for multiple affiliations

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -13,7 +13,7 @@ authors:
     affiliation: 1
   - name: Simon J Goring
     orcid: 0000-0002-2700-4605
-    affiliation: [2, 3]
+    affiliation: "2, 3"
 affiliations:
   - name: HT Data
     index: 1


### PR DESCRIPTION
The metadata for the paper is invalid due to the formatting of the affiliation entry for one of the authors. 
This PR fix the problem.
Re: [JOSS review](https://github.com/openjournals/joss-reviews/issues/5561)