### PR TITLE
Update Authors@R formatting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,12 +7,12 @@ Authors@R:
              family = "Socorro",
              role = c("aut", "cre"),
              email = "dominguezvid@wisc.edu",
-             comment = structure("0000-0002-7926-4935", .Names = "ORCID")),
+             comment = c(ORCID = "0000-0002-7926-4935")),
       person(given = "Simon",
              family = "Goring",
              role = c("aut"),
              email = "goring@wisc.edu",
-             comment = structure("0000-0002-2700-4605", .Names = "ORCID")))
+             comment = c(ORCID = "0000-0002-2700-4605")))
 URL: https://github.com/NeotomaDB/neotoma2
 BugReports: https://github.com/NeotomaDB/neotoma2/issues
 Description: Access and manipulation of data using the Neotoma Paleoecology Database.


### PR DESCRIPTION
Changed ORCID IDs in Authors@R from structure() to c() based on the latest example from "Writing R Extensions, Section 1.1.1: The DESCRIPTION file". https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#The-DESCRIPTION-file